### PR TITLE
230102 박동준 백준 1912 연속합 풀이

### DIFF
--- a/230102/박동준_boj_1912_연속합.py
+++ b/230102/박동준_boj_1912_연속합.py
@@ -1,0 +1,15 @@
+n = int(input())
+arr = list(map(int, input().split()))
+
+dp = [0]*len(arr)
+
+dp[0] = arr[0]
+max_num = dp[0]
+
+for i in range(1,len(arr)):
+    dp[i] = max(dp[i-1] + arr[i], arr[i], arr[i] + arr[i-1])
+
+    if max_num < dp[i]:
+        max_num = dp[i]
+
+print(max_num)

--- a/230102/박동준_boj_1912_연속합.py
+++ b/230102/박동준_boj_1912_연속합.py
@@ -1,15 +1,10 @@
 n = int(input())
 arr = list(map(int, input().split()))
-
 dp = [0]*len(arr)
-
 dp[0] = arr[0]
 max_num = dp[0]
-
 for i in range(1,len(arr)):
     dp[i] = max(dp[i-1] + arr[i], arr[i], arr[i] + arr[i-1])
-
     if max_num < dp[i]:
         max_num = dp[i]
-
 print(max_num)


### PR DESCRIPTION
### 문제유형 : DP
- 근거 : n의 범위 10만 -> 2중반복문은 1초 시간 초과 함

- dp로 풀게 된 방식

bf 적으로 표를 그려보았을 때
![image](https://user-images.githubusercontent.com/70469055/210233622-2399a210-dde1-43c5-a0bf-b6117ee41ca3.png)

1. 0번째 인덱스의 값은 채워준다.
2. 1번째 인덱스의 값에서 구간합을 구하는 방법은 총 3가지 이다
 - 첫 번째, dp에 직전 인덱스에 저장된 값에 현재 인덱스 값을 더한다.
 - 두 번째, 직전의 배열의 값에 현재 인덱스 값을 더한다.
 - 세 번째, 현재 인덱스의 값만 구한다.
3. 이 3가지의 값에서 최대가 되는 값을 구하면, 이전까지에서 나온 구간의 합중 최대 값만 남게 된다
4. 표에서 마지막 구간까지 규칙을 살펴보자, 이전구간에서 이미 최댓값으로 구해지지 않은 구간의 합은 다음 구간에 아무리 더해져도 최댓값이 될 수 없다.

해당 점화식을 구하기 위해서 표를 그려보고, 규칙을 찾아낸다. 2번에서 나온 3가지 값중 최댓값을 찾으면 앞서 구간에 관계없이 누적된 최댓값을 알 수 있고, 직전 값의 합만 구해졌기 때문에 앞서 몇번째 인덱스에서 시작했는지 구분 할 필요가 없어진다.
