### PR TITLE
230102 강소현 백준 1912 연속합 풀이

### DIFF
--- a/230102/강소현_boj_1912_연속합.java
+++ b/230102/강소현_boj_1912_연속합.java
@@ -1,0 +1,37 @@
+package boj;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/* boj 1912번 연속합 */
+public class boj_1912 {
+
+    static int[] dp;
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int N = Integer.parseInt(br.readLine());
+
+        dp = new int[N];
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            dp[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int sum = dp[0];
+
+        for (int i = 1; i < N; i++) {
+            if (dp[i - 1] < 0) {
+                dp[i] = Math.max(dp[i - 1] + dp[i], dp[i]);
+            } else {
+                dp[i] += dp[i - 1];
+            }
+            sum = Math.max(sum, dp[i]);
+        }
+
+        System.out.println(sum);
+
+    }
+}


### PR DESCRIPTION
<문제 풀이>
1. 음수와 양수로 기준을 나누어서 연속합을 구했다.
2. **(이전 값이 음수일 경우)** 이전 값과 현재 값이 둘 다 음수일 수도 있기 때문에 `(이전 값 + 현재 값)`과 `(현재 값)`을 비교해서 큰 값을 저장한다.
3. **(이전 값이 양수일 경우)** 그냥 더해준다.
4. 아까 33%에서 에러 떴었는데 알고 보니 sum 초깃값 설정을 0이 아닌 dp[0]으로 해줘야 했었다.

동탁 풀이를 보니....양수, 음수 나눌 필요가 없을 거 같다.. `Math.max()` 쓸 걸