### PR TITLE
230102 안영원 백준 1912 연속합 & 230104 프로그래머스 이진 변환 반복하기 풀이

### DIFF
--- a/230102/안영원_boj_1912_연속합.java
+++ b/230102/안영원_boj_1912_연속합.java
@@ -1,0 +1,29 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int n = Integer.parseInt(br.readLine());
+
+		int[] num = new int[n];
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		for (int i = 0; i < n; i++) {
+			num[i] = Integer.parseInt(st.nextToken()); 
+		}
+
+		// dp는 현재 위치에서 가장 최대의 합을 표시
+		int[] dp = new int[n];
+		dp[0] = num[0];
+
+		int answer = num[0];
+		// 연속된 합이 커지면 커진 값을 기록, 아니면 현재 위치 값을 기록
+		for (int i = 1; i < n; i++) {
+			dp[i] = Math.max(dp[i - 1] + num[i], num[i]);
+			answer = Math.max(answer, dp[i]);
+		}
+
+		System.out.println(answer);
+	}
+}

--- a/230104/안영원_programmers_이진 변환 반복하기.java
+++ b/230104/안영원_programmers_이진 변환 반복하기.java
@@ -1,0 +1,26 @@
+class Solution {
+    public int[] solution(String s) {
+        int[] answer = new int[2];
+        int zeroCnt = 0;
+        int cnt = 0;
+        
+        while (!s.equals("1")) {
+            cnt += 1;
+            String temp = "";
+            
+            for (int i = 0; i < s.length(); i++) {
+                if (s.charAt(i) == '0') {
+                    zeroCnt += 1;
+                } else {
+                    temp += s.charAt(i);
+                }
+            }
+            
+            s = Integer.toBinaryString(temp.length());
+        }
+        
+        answer[0] = cnt;
+        answer[1] = zeroCnt;
+        return answer;
+    }
+}


### PR DESCRIPTION
### 연속합

삽질을 좀 해서 늦었습니다.

테스트 케이스를 누적합으로 표현했을 때 순서대로
```
10 6 9 10 15 21 -14 -2 19 18
2 3 -1 2 6 2 8 13 8 9
-1 -3 -6 -10 -15
```

위와 같이 표현됨
그래서 첫번 째 경우 가장 작은 -14에서 시작해서 가장 큰 19가 되었을 때 두 수의 차이인 33
두번 째 경우 -1과 13의 차이인 14
세번 째 경우는 -1 이 나오면 되기 때문에 이에 맞춰서 누적합을 이용한 풀이를 사용했으나 62퍼의 벽을 넘지 못하고
알고리즘 종류를 보니 dp라서 다시 설계하였음.

---

DP로 풀이하였을 경우 DP는 현재 위치에서의 최대 합을 표현하게 되며
그래서 앞의 수와 현재 수를 더했을 때 더 크다면 그 값을 입력하고 작다면 현재 수의 값만 넣어주는 식으로 DP를 진행하며 풀이하면된다.

---

### 이진 변환 반복하기

문제에서 주어진 순서대로 진행하였음.
s가 1이 될 때까지 반복해야하기 때문에 while문에 해당 조건을 걸어두고 돌림.
그리디 방식으로 전체를 탐색하며 0이 있으면 cnt를 기록하고 아니라면 temp 문자열에 추가하여줌.

이 후 temp 문자열의 길이를 이진 변환하여 해당 값을 s에 덮어씌워주면서 반복을 진행함.