### PR TITLE
230116 강소현 프로그래머스 야근 지수 풀이

### DIFF
--- a/230116/강소현_programmers_야근 지수.java
+++ b/230116/강소현_programmers_야근 지수.java
@@ -1,0 +1,34 @@
+import java.util.*;
+
+class Solution {
+    public long solution(int n, int[] works) {
+        
+        // 우선순위 큐에 들어온 값 중 큰 값이 우선
+        PriorityQueue<Integer> pq = new PriorityQueue<>(Collections.reverseOrder());
+        
+        int sum = 0;
+        
+        for(int work : works) {
+            pq.offer(work); // 우선순위 큐에 담음
+            sum += work; // 남은 작업량 합
+        }
+        
+        // 퇴근까지 남은 n시간 >= 남은 작업량
+        // 야근을 하지 않으므로 야근 피로도 0
+        if(n >= sum) return 0;
+        
+        while(n != 0) {
+            int workCheck = pq.poll(); // 일의 작업량 많이 남은 거 우선적으로 처리
+            pq.offer(--workCheck);
+            n--; // 남은 시간 감소
+        }
+        
+        long answer = 0;
+        for(int p : pq) {
+            // 야근 피로도
+            answer += Math.pow(p, 2);
+        }
+        
+        return answer;
+    }
+}


### PR DESCRIPTION
**<문제 풀이>**
- 처음에 배열로 풀었다가 효율성에서 시간초과가 났던 문제. 이후 우선순위 큐를 사용해서 다시 풀었더니 정확성 + 효율성 통과.
- 우선순위 큐 사용
- 남은 작업량의 합을 먼저 구한 뒤, `퇴근까지 남은 시간 N보다 남은 작업량이 적으면` 야근을 하지 않으므로 `야근 피로도 0`
- 남은 작업량 중 가장 많이 `남은 작업량을 우선으로 하여 처리. 처리할 때 N시간도 감소`
- 처리한 남은 작업량을 `제곱 후 더하여 피로도를 구함`