### PR TITLE
 230116 안영원 프로그래머스 야근 지수 풀이

### DIFF
--- a/230116/안영원_programmers_야근 지수.java
+++ b/230116/안영원_programmers_야근 지수.java
@@ -1,0 +1,26 @@
+import java.util.*;
+
+class Solution {
+    public long solution(int n, int[] works) {
+        long answer = 0;
+        
+        PriorityQueue<Integer> pq = new PriorityQueue<>(Collections.reverseOrder());
+        for (int i = 0; i < works.length; i++) {
+            pq.offer(works[i]);
+        }
+        
+        while (n-- > 0) {
+            if (pq.size() == 0) break;
+            
+            int temp = pq.poll();
+            if (temp > 0) pq.offer(temp - 1);
+        }
+        
+        while (!pq.isEmpty()) {
+            int temp = pq.poll();
+            answer += temp * temp;
+        }
+        
+        return answer;
+    }
+}


### PR DESCRIPTION
배열을 매 번 정렬하는 방식을 사용했지만 시간 초과가 남.
그래서 같은 효과를 발생시키는 우선순위큐를 사용해서 정렬함.

제곱을 시키기 때문에 전체 일의 최대값이 적을 수록 총량이 적어짐.
그래서 정렬을 시킨 후 가장 큰 값을 -1씩 줄이는 방식을 사용하였습니다.